### PR TITLE
ci: permitir lanzar el deploy manualmente con workflow_dispatch

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -3,6 +3,7 @@ name: Build and Deploy
 on:
   push:
     branches: ["master"]
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
El workflow solo se dispara con push a master, así que no hay forma de republicar el sitio sin un commit nuevo.